### PR TITLE
Add option for user-defined remote control name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+names.h
+inputlircd

--- a/inputlircd.8
+++ b/inputlircd.8
@@ -9,9 +9,12 @@
 .Op Fl f
 .Op Fl c
 .Op Fl r Ar repeat-rate
+.Op Fl g
 .Op Fl m Ar keycode
 .Op Fl n Ar device name
 .Op Fl u Ar username
+.Op Fl t Ar path
+.Op Fl N Ar rc name
 .Ar device
 .Op Ar device Li ...
 .Sh DESCRIPTION
@@ -80,6 +83,12 @@ should be reported via lirc. The files should contain lines of the form
 .Pa KEY_FOO = bar .
 This is useful for backward compatibility.
 The default is not to use a translation table.
+.It Fl N Ar rc name
+Set the remote control name, that is, a value of the last field of LIRC broadcast messages.
+If there is more than one input event device, the specified name will be used for all of them.
+If
+.Ar rc name
+is not specified, the filesystem path of each input event device will be used as its remote control name.
 .It Ar device
 One or more input event devices.
 If you want to use

--- a/inputlircd.c
+++ b/inputlircd.c
@@ -63,6 +63,7 @@ static int sockfd;
 static bool grab = false;
 static int key_min = 88;
 static char *device = "/run/lirc/lircd";
+static char *rc_name = NULL;
 
 static bool capture_modifiers = false;
 static bool meta = false;
@@ -356,10 +357,12 @@ static void processevent(evdev_t *evdev, fd_set *permset) {
 	else 
 		repeat = 0;
 
+	char *name = rc_name ? rc_name : evdev->name;
+
 	if(KEY_NAME[event.code])
-		len = snprintf(message, sizeof message, "%x %x %s%s%s%s%s %s\n", event.code, repeat, ctrl ? "CTRL_" : "", shift ? "SHIFT_" : "", alt ? "ALT_" : "", meta ? "META_" : "", KEY_NAME[event.code], evdev->name);
+		len = snprintf(message, sizeof message, "%x %x %s%s%s%s%s %s\n", event.code, repeat, ctrl ? "CTRL_" : "", shift ? "SHIFT_" : "", alt ? "ALT_" : "", meta ? "META_" : "", KEY_NAME[event.code], name);
 	else
-		len = snprintf(message, sizeof message, "%x %x KEY_CODE_%d %s\n", event.code, repeat, event.code, evdev->name);
+		len = snprintf(message, sizeof message, "%x %x KEY_CODE_%d %s\n", event.code, repeat, event.code, name);
 
 	previous_input = current;
 	previous_event = event;
@@ -443,8 +446,8 @@ int main(int argc, char *argv[]) {
 
 	gettimeofday(&previous_input, NULL);
 
-	while((opt = getopt(argc, argv, "cd:gm:n:fu:r:t:")) != -1) {
-                switch(opt) {
+	while((opt = getopt(argc, argv, "cd:gm:n:fu:r:t:N:")) != -1) {
+		switch(opt) {
 			case 'd':
 				device = strdup(optarg);
 				break;
@@ -473,11 +476,14 @@ int main(int argc, char *argv[]) {
 			case 't':
 				translation_path = strdup(optarg);
 				break;
-                        default:
+			case 'N':
+				rc_name = strdup(optarg);
+				break;
+			default:
 				fprintf(stderr, "Unknown option!\n");
-                                return EX_USAGE;
-                }
-        }
+				return EX_USAGE;
+		}
+	}
 
 	if(argc <= optind && !named) {
 		fprintf(stderr, "Not enough arguments.\n");


### PR DESCRIPTION
`inputlircd` currently uses the filesystem path of the input device (e.g., `/dev/input/event0`) as a remote control name when emits broadcast messages (https://www.lirc.org/html/lircd.html#lbAG). It could be inconvinient if one physical device is represented as multiple event “devices” (for example, my remote, which emulates a keyboard, is exposed as three devices: Keyboard, Consumer Control, and System Control).

With the new option that this PR adds one can use an arbitrary string as a remote control name. If there is more than one input event device, the specified name will be used for all of them (what, in my case, simplifies message handling – all thee event devices are merged in one “remote”).