### PR TITLE
Autorepeat feature

### DIFF
--- a/inputlircd.8
+++ b/inputlircd.8
@@ -15,6 +15,8 @@
 .Op Fl u Ar username
 .Op Fl t Ar path
 .Op Fl N Ar rc name
+.Op Fl A Ar delay:period
+.Op Fl a
 .Ar device
 .Op Ar device Li ...
 .Sh DESCRIPTION
@@ -89,6 +91,14 @@ If there is more than one input event device, the specified name will be used fo
 If
 .Ar rc name
 is not specified, the filesystem path of each input event device will be used as its remote control name.
+.It Fl A Ar delay:period
+Add autorepeat function for devices which don't support it.
+.Ar delay:period
+sets autorepeat timing in milliseconds: delay before the first
+repeated key and the interval between consecutive repeats.
+.It Fl a
+Add autorepeat function for devices which don't support it. Use default delay (250) and
+period (33).
 .It Ar device
 One or more input event devices.
 If you want to use


### PR DESCRIPTION
This PR adds autorepeat feature for input devices that, for some reason, don't support it. It allows to solve issues like [this](https://forum.libreelec.tv/thread/9694-solved-vol-vol-auto-repeat-rf-remote) without patching kernel. My own remote control stopped sending autorepeats after a recent kernel upgrade.

If requested, autorepeat is turned on only for those devices that report (by ioctl) to not support it.

Adding this feature required some refactoring of the existing code.